### PR TITLE
fix: install missing ipfs-desktop dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,9 @@ RUN apk update && apk add --no-cache \
   yq \
   go \
   git \
-  jq
+  jq \
+  python3 \
+  build-base
 
 RUN git config --global gc.auto 0
 RUN git config --global protocol.version 2


### PR DESCRIPTION
Resolves #12 

Turns out lzma-native in ipfs-desktop needs python and GCC installed now. I ran the ipfs-desktop update command with this change and it successfully created https://github.com/ipfs/ipfs-desktop/pull/2539