### PR TITLE
feat: include list of NOT included commits in release PR

### DIFF
--- a/actions/prepare_branch.go
+++ b/actions/prepare_branch.go
@@ -2,8 +2,10 @@ package actions
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"os"
+	"strings"
 
 	gh "github.com/google/go-github/v48/github"
 	"github.com/ipfs/kuboreleaser/git"
@@ -183,6 +185,75 @@ func (ctx PrepareBranch) UpdateVersion(branch, source, currentVersionNumber, bas
 	return pr, nil
 }
 
+func (ctx PrepareBranch) GetBody(branch, foreword string) (string, error) {
+	kuboCommits, err := ctx.GitHub.Compare(repos.Kubo.Owner, repos.Kubo.Repo, branch, repos.Kubo.DefaultBranch)
+	if err != nil {
+		return "", err
+	}
+	file, err := ctx.GitHub.GetFile(repos.Kubo.Owner, repos.Kubo.Repo, "go.mod", branch)
+	if err != nil {
+		return "", err
+	}
+	if file == nil {
+		return "", fmt.Errorf("https://github.com/%s/%s/tree/%s/go.mod not found", repos.Kubo.Owner, repos.Kubo.Repo, branch)
+	}
+
+	content, err := base64.StdEncoding.DecodeString(*file.Content)
+	if err != nil {
+		return "", err
+	}
+
+	// find the boxo version
+	boxoVersion := ""
+	for _, line := range strings.Split(string(content[:]), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, fmt.Sprintf("github.com/%s/%s", repos.Boxo.Owner, repos.Boxo.Repo)) {
+			boxoVersion = strings.Split(line, " ")[1]
+			break
+		}
+	}
+	if boxoVersion == "" {
+		return "", fmt.Errorf("boxo version not found in https://github.com/%s/%s/tree/%s/go.mod", repos.Kubo.Owner, repos.Kubo.Repo, branch)
+	}
+
+	// find the boxo commit or tag in boxo version
+	boxoBranch := ""
+	if strings.Contains(boxoVersion, "-") {
+		boxoBranch = strings.Split(boxoVersion, "-")[2]
+	} else {
+		boxoBranch = boxoVersion
+	}
+
+	boxoCommits, err := ctx.GitHub.Compare(repos.Boxo.Owner, repos.Boxo.Repo, boxoBranch, repos.Boxo.DefaultBranch)
+	if err != nil {
+		return "", err
+	}
+
+	kuboCommitsStr := "```\n"
+	for _, commit := range kuboCommits[:100] {
+		kuboCommitsStr += fmt.Sprintf("%s %s\n", commit.GetSHA()[:7], strings.Split(commit.GetCommit().GetMessage(), "\n")[0])
+	}
+	kuboCommitsStr += "```"
+
+	boxoCommitsStr := "```\n"
+	for _, commit := range boxoCommits[:100] {
+		boxoCommitsStr += fmt.Sprintf("%s %s\n", commit.GetSHA()[:7], strings.Split(commit.GetCommit().GetMessage(), "\n")[0])
+	}
+	boxoCommitsStr += "```"
+
+	return fmt.Sprintf(`%s
+
+---
+
+### Kubo commits **NOT** included in this release
+
+%s
+
+### Boxo commits **NOT** included in this release
+
+%s`, foreword, kuboCommitsStr, boxoCommitsStr), nil
+}
+
 func (ctx PrepareBranch) Run() error {
 	log.Info("I'm going to create PRs that update the version in the release branch and the master branch.")
 	log.Info("I'm also going to update the changelog if we're performing the final release. Please note that it might take a while because I have to clone a looooot of repos.")
@@ -203,6 +274,17 @@ func (ctx PrepareBranch) Run() error {
 	draft := ctx.Version.IsPrerelease()
 
 	pr, err := ctx.UpdateVersion(branch, source, currentVersionNumber, base, title, body, draft)
+	if err != nil {
+		return err
+	}
+
+	body, err = ctx.GetBody(branch, body)
+	if err != nil {
+		return err
+	}
+
+	pr.Body = &body
+	err = ctx.GitHub.UpdatePR(pr)
 	if err != nil {
 		return err
 	}

--- a/actions/prepare_branch.go
+++ b/actions/prepare_branch.go
@@ -245,11 +245,11 @@ func (ctx PrepareBranch) GetBody(branch, foreword string) (string, error) {
 
 ---
 
-### Kubo commits **NOT** included in this release
+#### Kubo commits **NOT** included in this release
 
 %s
 
-### Boxo commits **NOT** included in this release
+#### Boxo commits **NOT** included in this release
 
 %s`, foreword, kuboCommitsStr, boxoCommitsStr), nil
 }

--- a/github/github.go
+++ b/github/github.go
@@ -359,9 +359,9 @@ func (c *Client) GetOrCreatePR(owner, repo, head, base, title, body string, draf
 
 func (c *Client) UpdatePR(pr *github.PullRequest) error {
 	log.WithFields(log.Fields{
-		"owner":    pr.Base.Repo.Owner.GetLogin(),
-		"repo":     pr.Base.Repo.GetName(),
-		"number":   pr.GetNumber(),
+		"owner":  pr.Base.Repo.Owner.GetLogin(),
+		"repo":   pr.Base.Repo.GetName(),
+		"number": pr.GetNumber(),
 	}).Debug("Updating PR...")
 
 	_, _, err := c.v3.PullRequests.Edit(context.Background(), pr.Base.Repo.Owner.GetLogin(), pr.Base.Repo.GetName(), pr.GetNumber(), pr)

--- a/github/github.go
+++ b/github/github.go
@@ -357,6 +357,17 @@ func (c *Client) GetOrCreatePR(owner, repo, head, base, title, body string, draf
 	return pr, nil
 }
 
+func (c *Client) UpdatePR(pr *github.PullRequest) error {
+	log.WithFields(log.Fields{
+		"owner":    pr.Base.Repo.Owner.GetLogin(),
+		"repo":     pr.Base.Repo.GetName(),
+		"number":   pr.GetNumber(),
+	}).Debug("Updating PR...")
+
+	_, _, err := c.v3.PullRequests.Edit(context.Background(), pr.Base.Repo.Owner.GetLogin(), pr.Base.Repo.GetName(), pr.GetNumber(), pr)
+	return err
+}
+
 func (c *Client) GetFile(owner, repo, path, ref string) (*github.RepositoryContent, error) {
 	log.WithFields(log.Fields{
 		"owner": owner,
@@ -745,4 +756,37 @@ func (c *Client) GetTag(owner, repo, tag string) (*github.Tag, error) {
 	}
 
 	return t, err
+}
+
+func (c *Client) Compare(owner, repo, base, head string) ([]*github.RepositoryCommit, error) {
+	log.WithFields(log.Fields{
+		"owner": owner,
+		"repo":  repo,
+		"base":  base,
+		"head":  head,
+	}).Debug("Comparing...")
+
+	opts := &github.ListOptions{PerPage: 100}
+	var commits []*github.RepositoryCommit
+	for {
+		cs, r, err := c.v3.Repositories.CompareCommits(context.Background(), owner, repo, base, head, opts)
+		if err != nil {
+			return nil, err
+		}
+		commits = append(commits, cs.Commits...)
+		if r.NextPage == 0 {
+			break
+		}
+		opts.Page = r.NextPage
+	}
+
+	if len(commits) > 0 {
+		log.WithFields(log.Fields{
+			"commits": len(commits),
+		}).Debug("Found commits")
+	} else {
+		log.Debug("Commits not found")
+	}
+
+	return commits, nil
 }

--- a/repos/boxo.go
+++ b/repos/boxo.go
@@ -1,13 +1,13 @@
 package repos
 
 type boxo struct {
-	Owner                            string
-	Repo                             string
-	DefaultBranch                    string
+	Owner         string
+	Repo          string
+	DefaultBranch string
 }
 
 var Boxo = boxo{
-	Owner:                            "ipfs",
-	Repo:                             "boxo",
-	DefaultBranch:                    "main",
+	Owner:         "ipfs",
+	Repo:          "boxo",
+	DefaultBranch: "main",
 }

--- a/repos/boxo.go
+++ b/repos/boxo.go
@@ -1,0 +1,13 @@
+package repos
+
+type boxo struct {
+	Owner                            string
+	Repo                             string
+	DefaultBranch                    string
+}
+
+var Boxo = boxo{
+	Owner:                            "ipfs",
+	Repo:                             "boxo",
+	DefaultBranch:                    "main",
+}


### PR DESCRIPTION
Resolves https://github.com/ipfs/kuboreleaser/issues/6

With this change, the PR created by the `prepare-branch` command will include a list of up to 100 most recent commits from boxo/kubo that are not being released. The list will get updated for every RC, patch, final release.

###### Testing

Example release PR body (diff between current Kubo `release` branch state and Kubo `master` branch):

> This PR creates release [v_](https://github.com/ipfs/kubo/issues/_).
>
> ---
> 
> #### Kubo commits **NOT** included in this release
> 
> ```
> cfe52e0 chore: update version
> 344431d Merge pull request #9937 from ipfs/version-update-v0.21
> 18db593 fix: more stable prometheus test (#9944)
> f039771 chore(docs): typo http→https
> c93e267 feat: webui@4.0.1 (#9940)
> ced4be8 chore: Update .github/workflows/stale.yml [skip ci]
> b8da86e chore: label dependabot PRs
> f5f6b66 fix(cmd): useful errors in dag import (#9945)
> b685355 feat!: dag import - don't pin roots by default (#9926)
> 44c5ec0 chore: update dht and libp2p for identify stream block
> 2cbee81 docs: fix 0.21 changelog
> 82fd9ec cmds/dag/import: pin roots by default (#9966)
> 27398ce chore(deps): bump docker/build-push-action from 2 to 4 (#9954)
> 364686a chore(deps): bump docker/setup-buildx-action from 1 to 2 (#9952)
> d4eb09f chore(deps): bump codecov/codecov-action from 3.1.0 to 3.1.4 (#9951)
> 9298e31 chore(deps): bump docker/setup-qemu-action from 1 to 2 (#9953)
> 6c47b81 chore: Update .github/dependabot.yml [skip ci]
> 8bba03d chore: bump boxo to 0.10.1 (#9970)
> f3ca759 chore: bump go-libp2p-kad-dht for deadlock fix
> 5156f21 feat(ipns): records with V2-only signatures (#9932)
> 05bcae4 chore(deps): bump actions/checkout from 2 to 3 (#9975)
> 873c6e1 chore(deps): bump actions/github-script from 4 to 6 (#9977)
> 67cd516 chore(deps): bump docker/login-action from 1.10.0 to 2.2.0 (#9979)
> 1972a49 fix: docker repository initialization race condition
> 61f0aa0 ci: fix checking state of CI in ipfs-webui (#9969)
> 3da4e5b fix(gateway): include CORS on subdomain redirects (#9994)
> 4047650 feat: update conformance to v0.2
> f2a6c4f fix: correctly handle migration of configs
> 92f651f chore: Update .github/workflows/stale.yml [skip ci]
> dae4183 chore: bump to boxo master
> 394d72d refactor: replace boxo/ipld/car by ipld/go-car
> da44c9f docs: Gateway.HTTPHeaders
> 0d5a933 docs: update refs to kuboreleaser in RELEASE_ISSUE_TEMPLATE.md
> c00cee5 docs: update RELEASE_ISSUE_TEMPLATE.md with a warning about npm publish
> f797e9e docs: skip check before prepare branch in RELEASE_ISSUE_TEMPLATE.md
> 0c890de Merge branch 'master' into merge-release-v0.21.0
> 895963b Merge pull request #10008 from ipfs/merge-release-v0.21.0
> 82e0a44 feat: webui@4.0.2
> c293d62 ci: add changelog update checker workflow [skip changelog] (#10002)
> 4a5e99d docs: add Brave to RELEASE_ISSUE_TEMPLATE.md (#10012)
> ```
> 
> #### Boxo commits **NOT** included in this release
> 
> ```
> 1ec05d7 docs: prepare changelog for next release [ci skip]
> 417c5f7 feat(ipns): refactored IPNS package with lean records (#339)
> 290613a fix(ipns): racy parallel tests writing to the same error variable (#371)
> 0962474 chore: Add fuzz testing to reproduce a panic
> bd1314e fix: switch to crypto/rand from math/rand for some parts of the fuzz testing
> cb69599 Merge pull request #394 from ipfs/test/fuzz-mfs
> 72238ea fix(gateway): ensure 'X-Ipfs-Root' header is valid (#337)
> a87f9ed fix(gateway): include CORS on subdomain redirects (#395)
> 9b8dea9 refactor: golang-lru → golang-lru/v2
> 8424cf4 feat: update conformance to v0.2
> a91e44d chore: Update .github/workflows/stale.yml [skip ci]
> fdad9f9 refactor: replace boxo/ipld/car by ipld/go-car (#400)
> 61f2939 Merge pull request #401 from ipfs/release-v0.10.2
> 73193c4 Merge branch 'release' into merge-release-v0.10.2
> cfcbdbc Merge pull request #403 from ipfs/merge-release-v0.10.2
> 85b7e0a docs(readme): new logo and header (#405)
> 0c3bdb0 docs(blockstore): clarify AllKeysChan (#363)
> cfad09d ci: add changelog update checker workflow (#398)
> ``` 