### PR TITLE
fix: docker env init

### DIFF
--- a/kuboreleaser
+++ b/kuboreleaser
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
+if ! test -f ".env"; then
+    ./actions/embed/.env.sh
+    echo ".env created, try executing kuboreleaser again"
+    exit 0
+fi
+
 docker run -it --env-file .env kuboreleaser "$@"

--- a/kuboreleaser
+++ b/kuboreleaser
@@ -6,4 +6,4 @@ if ! test -f ".env"; then
     exit 0
 fi
 
-docker run -it --env-file .env -v $(pwd)/.env:/.env:ro kuboreleaser "$@"
+docker run -it --rm --env-file .env -v $(pwd)/.env:/.env:ro kuboreleaser "$@"

--- a/kuboreleaser
+++ b/kuboreleaser
@@ -6,4 +6,4 @@ if ! test -f ".env"; then
     exit 0
 fi
 
-docker run -it --env-file .env kuboreleaser "$@"
+docker run -it --env-file .env -v $(pwd)/.env:/.env:ro kuboreleaser "$@"


### PR DESCRIPTION
this PR aims to fix a bit of a chicken-or-egg problem:

- #31  added `env` command
- `./kuboreleaser` is a wrapper script that runs docker image `docker run -it --env-file .env kuboreleaser "$@"`
- it is not possible to initialize `./kuboreleaser env` because  docker errors with `docker: open .env: no such file or directory.`


(found while working on https://github.com/ipfs/kubo/issues/10436)